### PR TITLE
Ensure case names have same access level as enum

### DIFF
--- a/Templates/AutoCaseName.stencil
+++ b/Templates/AutoCaseName.stencil
@@ -1,8 +1,7 @@
-
 {% for type in types.implementing.AutoCaseName|enum %}
 // MARK: {{type.name}}
 
-extension {{type.name}} {
+{{type.accessLevel}} extension {{type.name}} {
     enum CaseName: String {
     {% for p in type.cases %}
         case {{p.name}}


### PR DESCRIPTION
`AutoCaseName` totally rules! Just wanted to propose a small change that improves usefulness by keeping the generated `enum.CaseName` the same scope as the `enum` itself, instead of defaulting to `internal`.

I also decreased the top spacing so SwiftLint doesn’t complain about too many empty spaces, but that might be unnecessary. 